### PR TITLE
check on effective or direct deps for facet detection

### DIFF
--- a/src/main/java/org/jboss/forge/addon/springboot/SpringBootFacet.java
+++ b/src/main/java/org/jboss/forge/addon/springboot/SpringBootFacet.java
@@ -70,6 +70,6 @@ public class SpringBootFacet extends AbstractProjectFacet {
    @Override
    public boolean isInstalled() {
       final DependencyFacet facet = getFaceted().getFacet(DependencyFacet.class);
-      return facet.hasDirectDependency(SPRING_BOOT_STARTER);
+      return facet.hasEffectiveDependency(SPRING_BOOT_STARTER) || facet.hasDirectDependency(SPRING_BOOT_STARTER);
    }
 }


### PR DESCRIPTION
This fixes https://github.com/forge/springboot-addon/issues/12

The facet dectection ( `isInstalled` method) was only checking on direct dependency of `spring-boot-starter` but when installing other starters or deps that has already this deps it isn't a direct dependency anymore. 

This fix checks for both.

@cmoulliard @metacosm Can you review ? 
